### PR TITLE
feat: Implementación inicial de ASTVisitor y LLVMVisitor para generación de código

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Versión mínima requerida de CMake
 cmake_minimum_required(VERSION 3.10)
 enable_testing()
 project(UmbraLang VERSION 0.1.0 LANGUAGES CXX)
+enable_language(C)  # Habilita el lenguaje C
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -17,7 +17,6 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-
 # Flags del compilador para Debug y Release
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(STATUS "Configuring Debug build")
@@ -27,7 +26,6 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 endif()
 
-
 # Opciones de compilación según el compilador
 if(MSVC)
   add_compile_options(/W4 /WX)
@@ -35,14 +33,13 @@ else()
   add_compile_options(-Wall -Wextra )
 endif()
 
-
 # Paquete de LLVM
-#find_package(LLVM REQUIRED CONFIG)
-#message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-#message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-#include_directories(${LLVM_INCLUDE_DIRS})
-#add_definitions(${LLVM_DEFINITIONS})
-
+find_package(LLVM REQUIRED CONFIG)
+if(LLVM_FOUND)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  include_directories(${LLVM_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+endif()
 
 # Biblioteca del analizador léxico 
 add_library(umbra_lexer STATIC
@@ -52,8 +49,6 @@ add_library(umbra_lexer STATIC
     src/error/ErrorManager.cpp
     src/preprocessor/Preprocessor.cpp
 )
-
-
 
 # Ejecutable del compilador Umbra
 file(GLOB_RECURSE SOURCES
@@ -73,7 +68,6 @@ set_target_properties(umbra_compiler
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-
 
 # Agregar pruebas
 add_subdirectory(tests)

--- a/src/ast/ASTVisitor.h
+++ b/src/ast/ASTVisitor.h
@@ -1,0 +1,66 @@
+#ifndef UMBRA_AST_VISITOR_H
+#define UMBRA_AST_VISITOR_H
+
+namespace umbra {
+/// Forward declarations
+class ProgramNode;
+class FunctionDefinition;
+class ParameterList;
+class Type;
+class Identifier;
+class VariableDeclaration;
+class AssignmentStatement;
+class Conditional;
+class Loop;
+class MemoryManagement;
+class ReturnStatement;
+class FunctionCall;
+class Literal;
+class Statement;
+class NumericLiteral;
+class BooleanLiteral;
+class CharLiteral;
+class StringLiteral;
+class BinaryExpression;
+class UnaryExpression;
+class PrimaryExpression;
+class ArrayAccessExpression;
+class TernaryExpression;
+class CastExpression;
+class MemberAccessExpression;
+
+class ASTVisitor {
+public:
+    virtual ~ASTVisitor() = default;
+
+    // Declaraciones de metodos de visita para cada nodo
+    virtual void visit(ProgramNode& node) = 0;
+    virtual void visit(FunctionDefinition& node) = 0;
+    virtual void visit(ParameterList& node) = 0;
+    virtual void visit(Type& node) = 0;
+    virtual void visit(Identifier& node) = 0;
+    virtual void visit(Statement& node) = 0;
+    virtual void visit(VariableDeclaration& node) = 0;
+    virtual void visit(AssignmentStatement& node) = 0;
+    virtual void visit(Conditional& node) = 0;
+    virtual void visit(Loop& node) = 0;
+    virtual void visit(MemoryManagement& node) = 0;
+    virtual void visit(ReturnStatement& node) = 0;
+    virtual void visit(FunctionCall& node) = 0;
+    virtual void visit(Literal& node) = 0;
+    virtual void visit(NumericLiteral& node) = 0;
+    virtual void visit(BooleanLiteral& node) = 0;
+    virtual void visit(CharLiteral& node) = 0;
+    virtual void visit(StringLiteral& node) = 0;
+    virtual void visit(BinaryExpression& node) = 0;
+    virtual void visit(UnaryExpression& node) = 0;
+    virtual void visit(PrimaryExpression& node) = 0;
+    virtual void visit(ArrayAccessExpression& node) = 0;
+    virtual void visit(TernaryExpression& node) = 0;
+    virtual void visit(CastExpression& node) = 0;
+    virtual void visit(MemberAccessExpression& node) = 0;   
+};
+
+}
+
+#endif

--- a/src/ast/ASTVisitor.h
+++ b/src/ast/ASTVisitor.h
@@ -1,66 +1,198 @@
+/*
+ * ASTVisitor Header for Umbra Language Compiler
+ * Copyright (C) 2023 Free Software Foundation, Inc.
+ * 
+ * This file is part of the Umbra Compiler Project.
+ * Contributed by Ginozza (jsimancas@unimagdalena.edu.co).
+ * 
+ * The Umbra Compiler is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * The Umbra Compiler is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the Umbra Compiler; see the file COPYING.LIB. If
+ * not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef UMBRA_AST_VISITOR_H
 #define UMBRA_AST_VISITOR_H
 
 namespace umbra {
-/// Forward declarations
-class ProgramNode;
-class FunctionDefinition;
-class ParameterList;
-class Type;
-class Identifier;
-class VariableDeclaration;
-class AssignmentStatement;
-class Conditional;
-class Loop;
-class MemoryManagement;
-class ReturnStatement;
-class FunctionCall;
-class Literal;
-class Statement;
-class NumericLiteral;
-class BooleanLiteral;
-class CharLiteral;
-class StringLiteral;
-class BinaryExpression;
-class UnaryExpression;
-class PrimaryExpression;
-class ArrayAccessExpression;
-class TernaryExpression;
-class CastExpression;
-class MemberAccessExpression;
 
+/**
+ * @brief Abstract base class for visiting nodes in an Abstract Syntax Tree (AST).
+ * 
+ * The `ASTVisitor` class defines a set of virtual methods for visiting different
+ * types of nodes in an AST. Subclasses of `ASTVisitor` implement these methods to
+ * perform specific actions, such as generating code, performing semantic analysis,
+ * or printing the AST.
+ */
 class ASTVisitor {
 public:
+    /**
+     * @brief Virtual destructor for the ASTVisitor class.
+     * 
+     * Ensures proper cleanup of resources when a subclass instance is destroyed.
+     */
     virtual ~ASTVisitor() = default;
 
-    // Declaraciones de metodos de visita para cada nodo
+    /**
+     * @brief Visits a ProgramNode to process the entire program structure.
+     * @param node The ProgramNode representing the program.
+     */
     virtual void visit(ProgramNode& node) = 0;
+
+    /**
+     * @brief Visits a FunctionDefinition node to process a function definition.
+     * @param node The FunctionDefinition node containing the function's metadata.
+     */
     virtual void visit(FunctionDefinition& node) = 0;
+
+    /**
+     * @brief Visits a ParameterList node to process a function's parameters.
+     * @param node The ParameterList node containing the function's parameters.
+     */
     virtual void visit(ParameterList& node) = 0;
+
+    /**
+     * @brief Visits a Type node to process a type declaration.
+     * @param node The Type node representing a variable or function type.
+     */
     virtual void visit(Type& node) = 0;
+
+    /**
+     * @brief Visits an Identifier node to process a variable or function name.
+     * @param node The Identifier node representing a name.
+     */
     virtual void visit(Identifier& node) = 0;
+
+    /**
+     * @brief Visits a Statement node to process a single statement in the program.
+     * @param node The Statement node representing a generic statement.
+     */
     virtual void visit(Statement& node) = 0;
+
+    /**
+     * @brief Visits a VariableDeclaration node to process a variable declaration.
+     * @param node The VariableDeclaration node containing the variable's metadata.
+     */
     virtual void visit(VariableDeclaration& node) = 0;
+
+    /**
+     * @brief Visits an AssignmentStatement node to process an assignment operation.
+     * @param node The AssignmentStatement node containing the target and value.
+     */
     virtual void visit(AssignmentStatement& node) = 0;
+
+    /**
+     * @brief Visits a Conditional node to process a conditional statement (if-else).
+     * @param node The Conditional node containing the condition and branches.
+     */
     virtual void visit(Conditional& node) = 0;
+
+    /**
+     * @brief Visits a Loop node to process a loop construct.
+     * @param node The Loop node containing the condition and body.
+     */
     virtual void visit(Loop& node) = 0;
+
+    /**
+     * @brief Visits a MemoryManagement node to process memory allocation/deallocation.
+     * @param node The MemoryManagement node specifying the action (allocate/deallocate).
+     */
     virtual void visit(MemoryManagement& node) = 0;
+
+    /**
+     * @brief Visits a ReturnStatement node to process a return statement.
+     * @param node The ReturnStatement node containing the return value (can be nullptr).
+     */
     virtual void visit(ReturnStatement& node) = 0;
+
+    /**
+     * @brief Visits a FunctionCall node to process a function call.
+     * @param node The FunctionCall node containing the callee and arguments.
+     */
     virtual void visit(FunctionCall& node) = 0;
+
+    /**
+     * @brief Visits a Literal node to process a generic literal.
+     * Specific literals are handled by their respective visitor methods.
+     * @param node The Literal node.
+     */
     virtual void visit(Literal& node) = 0;
+
+    /**
+     * @brief Visits a NumericLiteral node to process a numeric literal.
+     * @param node The NumericLiteral node containing the numeric value.
+     */
     virtual void visit(NumericLiteral& node) = 0;
+
+    /**
+     * @brief Visits a BooleanLiteral node to process a boolean literal.
+     * @param node The BooleanLiteral node containing the boolean value.
+     */
     virtual void visit(BooleanLiteral& node) = 0;
+
+    /**
+     * @brief Visits a CharLiteral node to process a character literal.
+     * @param node The CharLiteral node containing the character value.
+     */
     virtual void visit(CharLiteral& node) = 0;
+
+    /**
+     * @brief Visits a StringLiteral node to process a string literal.
+     * @param node The StringLiteral node containing the string value.
+     */
     virtual void visit(StringLiteral& node) = 0;
+
+    /**
+     * @brief Visits a BinaryExpression node to process a binary expression.
+     * @param node The BinaryExpression node containing the operator and operands.
+     */
     virtual void visit(BinaryExpression& node) = 0;
+
+    /**
+     * @brief Visits a UnaryExpression node to process a unary expression.
+     * @param node The UnaryExpression node containing the operator and operand.
+     */
     virtual void visit(UnaryExpression& node) = 0;
+
+    /**
+     * @brief Visits a PrimaryExpression node to process a primary expression.
+     * @param node The PrimaryExpression node containing the expression type.
+     */
     virtual void visit(PrimaryExpression& node) = 0;
+
+    /**
+     * @brief Visits an ArrayAccessExpression node to process an array access.
+     * @param node The ArrayAccessExpression node containing the array and index.
+     */
     virtual void visit(ArrayAccessExpression& node) = 0;
+
+    /**
+     * @brief Visits a TernaryExpression node to process a ternary expression.
+     * @param node The TernaryExpression node containing the condition and branches.
+     */
     virtual void visit(TernaryExpression& node) = 0;
+
+    /**
+     * @brief Visits a CastExpression node to process a type cast.
+     * @param node The CastExpression node containing the target type and expression.
+     */
     virtual void visit(CastExpression& node) = 0;
-    virtual void visit(MemberAccessExpression& node) = 0;   
+
+    /**
+     * @brief Visits a MemberAccessExpression node to process member access.
+     * @param node The MemberAccessExpression node containing the object and member.
+     */
+    virtual void visit(MemberAccessExpression& node) = 0;
 };
 
-}
+} // namespace umbra
 
-#endif
+#endif // UMBRA_AST_VISITOR_H

--- a/src/ast/LLVMVisitor.cpp
+++ b/src/ast/LLVMVisitor.cpp
@@ -1,0 +1,528 @@
+/*
+ * LLVMVisitor Implementation for Umbra Language Compiler
+ * Copyright (C) 2023 Free Software Foundation, Inc.
+ * 
+ * This file is part of the Umbra Compiler Project.
+ * Contributed by Ginozza (jsimancas@unimagdalena.edu.co).
+ * 
+ * The Umbra Compiler is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * The Umbra Compiler is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the Umbra Compiler; see the file COPYING.LIB. If
+ * not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file contains the implementation of the LLVMVisitor class, which
+ * generates LLVM Intermediate Representation (IR) code from an Abstract
+ * Syntax Tree (AST). It traverses the AST nodes and emits corresponding
+ * LLVM IR instructions using the LLVM API.
+ * 
+ * The LLVMVisitor supports various constructs such as function definitions,
+ * variable declarations, assignments, conditionals, loops, memory management,
+ * and expressions. It uses LLVM's IRBuilder to construct the IR dynamically.
+ * 
+ * Key Features:
+ * - Generates LLVM IR for a subset of the Umbra language.
+ * - Supports basic control flow constructs like if-else and loops.
+ * - Handles memory allocation and deallocation using malloc/free.
+ * - Implements array indexing and pointer arithmetic.
+ * - Provides support for binary and unary expressions, literals, and function calls.
+ * 
+ * Contents:
+ * 1. Program and Function Definitions
+ *    - visit(ProgramNode& node)
+ *    - visit(FunctionDefinition& node)
+ * 
+ * 2. Variable Declarations and Assignments
+ *    - visit(VariableDeclaration& node)
+ *    - visit(AssignmentStatement& node)
+ * 
+ * 3. Control Flow Constructs
+ *    - visit(Conditional& node)
+ *    - visit(Loop& node)
+ * 
+ * 4. Memory Management
+ *    - visit(MemoryManagement& node)
+ * 
+ * 5. Expressions
+ *    - visit(BinaryExpression& node)
+ *    - visit(UnaryExpression& node)
+ *    - visit(ArrayAccessExpression& node)
+ *    - visit(TernaryExpression& node)
+ *    - visit(CastExpression& node)
+ * 
+ * 6. Literals and Function Calls
+ *    - visit(Literal& node)
+ *    - visit(FunctionCall& node)
+ * 
+ * 7. Miscellaneous
+ *    - visit(ReturnStatement& node)
+ *    - visit(MemberAccessExpression& node)
+ * 
+ * Vital Statistics:
+ * - Supported pointer representation:       8 bytes (LLVM default)
+ * - Supported size_t representation:        8 bytes (LLVM default)
+ * - Alignment:                              Determined by LLVM types
+ * - Thread-safety:                          Not inherently thread-safe
+ * 
+ * Quickstart:
+ * To compile this implementation, ensure you have LLVM installed and properly
+ * configured. Use CMake or a Makefile to build the project. Example:
+ *   mkdir build && cd build
+ *   cmake ..
+ *   make
+ * 
+ * Why use this LLVMVisitor?
+ * This implementation provides a foundation for generating LLVM IR from an AST,
+ * enabling optimization and machine code generation through LLVM's powerful tools.
+ * It is designed to be extensible, allowing additional language features to be
+ * supported with minimal changes.
+ * 
+ * For more information on LLVM, see:
+ * https://llvm.org/docs/
+ */
+/**
+ * @brief LLVMVisitor.cpp Pending Tasks
+ * TODO: Complete the implementation of all visit methods
+ * TODO: Implement error handling 
+ * TODO: Check LLVM code and add optimizations
+ * TODO: Implement runtime library for security checks
+ * TODO: Integrate complete type system
+ */
+#include "LLVMVisitor.h"
+#include "Nodes.h" 
+#include <llvm/IR/Module.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <memory> // Para std::unique_ptr
+#include <map>
+#include <string>
+
+using namespace llvm;
+
+namespace umbra {
+
+/**
+ * @brief Constructs an LLVMVisitor object.
+ * Initializes the LLVM context, module, and IRBuilder.
+ */
+LLVMVisitor::LLVMVisitor() : builder(context) {
+    module = std::make_unique<llvm::Module>("UmbraModule", context);
+}
+
+/**
+ * @brief Visits a ProgramNode to generate LLVM IR for the entire program.
+ * @param node The ProgramNode representing the program structure.
+ */
+void LLVMVisitor::visit(ProgramNode& node) {
+    for (auto& func : node.functions) {
+        func->accept(*this);
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a function definition.
+ * @param node The FunctionDefinition node containing the function's metadata.
+ */
+void LLVMVisitor::visit(FunctionDefinition& node) {
+    llvm::Type* llvmReturnType = typeToLLVM(*node.returnType);
+    std::vector<llvm::Type*> paramTypes;
+    for (auto& param : node.parameters->parameters) {
+        paramTypes.push_back(typeToLLVM(*param.first));
+    }
+    FunctionType* funcType = FunctionType::get(llvmReturnType, paramTypes, false);
+    Function* func = Function::Create(
+        funcType,
+        Function::ExternalLinkage,
+        node.name->name,
+        module.get()
+    );
+    BasicBlock* entry = BasicBlock::Create(context, "entry", func);
+    builder.SetInsertPoint(entry);
+
+    // Assign names to arguments based on the parameter list.
+    unsigned idx = 0;
+    for (auto& arg : func->args()) {
+        arg.setName(node.parameters->parameters[idx++].second->name);
+    }
+
+    // Generate the function body.
+    for (auto& stmt : node.body) {
+        stmt->accept(*this);
+    }
+
+    // If the function is void and no terminator was generated, add a RetVoid.
+    if (llvmReturnType->isVoidTy() && !builder.GetInsertBlock()->getTerminator()) {
+        builder.CreateRetVoid();
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a variable declaration.
+ * @param node The VariableDeclaration node containing the variable's metadata.
+ */
+void LLVMVisitor::visit(VariableDeclaration& node) {
+    llvm::Type* llvmType = typeToLLVM(*node.type);
+    AllocaInst* alloca = builder.CreateAlloca(llvmType, nullptr, node.name->name);
+    symbolTable[node.name->name] = alloca;
+    if (node.initializer) {
+        node.initializer->accept(*this);
+        builder.CreateStore(currentValue, alloca);
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for an assignment statement.
+ * @param node The AssignmentStatement node containing the target and value.
+ */
+void LLVMVisitor::visit(AssignmentStatement& node) {
+    node.value->accept(*this);
+    llvm::Value* rhs = currentValue;
+    if (symbolTable.find(node.target->name) != symbolTable.end()) {
+        llvm::Value* ptr = symbolTable[node.target->name];
+        if (node.index) {
+            node.index->accept(*this);
+            llvm::Value* indexVal = currentValue;
+            std::vector<llvm::Value*> indices;
+            indices.push_back(builder.getInt32(0)); // Zero index for the array's first dimension.
+            indices.push_back(indexVal);
+            llvm::Type* pointeeType = ptr->getType()->getPointerElementType();
+            llvm::Value* elemPtr = builder.CreateGEP(pointeeType, ptr, indices, "elemPtr");
+            builder.CreateStore(rhs, elemPtr);
+        } else {
+            builder.CreateStore(rhs, ptr);
+        }
+    } else {
+        currentValue = nullptr;
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a conditional statement (if-else).
+ * @param node The Conditional node containing the condition and branches.
+ */
+void LLVMVisitor::visit(Conditional& node) {
+    Function* parentFunc = builder.GetInsertBlock()->getParent();
+    BasicBlock* mergeBB = BasicBlock::Create(context, "ifcont", parentFunc);
+
+    if (!node.branches.empty()) {
+        auto& firstBranch = node.branches[0];
+        firstBranch.condition->accept(*this);
+        llvm::Value* condVal = currentValue;
+        BasicBlock* thenBB = BasicBlock::Create(context, "then", parentFunc);
+        BasicBlock* elseBB = node.elseBranch.empty() ? mergeBB : BasicBlock::Create(context, "else", parentFunc);
+        builder.CreateCondBr(condVal, thenBB, elseBB);
+
+        // "Then" block.
+        builder.SetInsertPoint(thenBB);
+        for (auto& stmt : firstBranch.body) {
+            stmt->accept(*this);
+        }
+        if (!builder.GetInsertBlock()->getTerminator())
+            builder.CreateBr(mergeBB);
+
+        // "Else" block, if it exists.
+        if (!node.elseBranch.empty()) {
+            builder.SetInsertPoint(elseBB);
+            for (auto& stmt : node.elseBranch) {
+                stmt->accept(*this);
+            }
+            if (!builder.GetInsertBlock()->getTerminator())
+                builder.CreateBr(mergeBB);
+        }
+        builder.SetInsertPoint(mergeBB);
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a loop construct.
+ * @param node The Loop node containing the condition and body.
+ */
+void LLVMVisitor::visit(Loop& node) {
+    Function* parentFunc = builder.GetInsertBlock()->getParent();
+    BasicBlock* condBB = BasicBlock::Create(context, "loopcond", parentFunc);
+    BasicBlock* loopBB = BasicBlock::Create(context, "loop", parentFunc);
+    BasicBlock* afterBB = BasicBlock::Create(context, "afterloop", parentFunc);
+    builder.CreateBr(condBB);
+
+    // Condition block.
+    builder.SetInsertPoint(condBB);
+    node.condition->accept(*this);
+    llvm::Value* condVal = currentValue;
+    builder.CreateCondBr(condVal, loopBB, afterBB);
+
+    // Loop body block.
+    builder.SetInsertPoint(loopBB);
+    for (auto& stmt : node.body) {
+        stmt->accept(*this);
+    }
+    if (!builder.GetInsertBlock()->getTerminator())
+        builder.CreateBr(condBB);
+
+    // After-loop block.
+    builder.SetInsertPoint(afterBB);
+}
+
+/**
+ * @brief Generates LLVM IR for memory management operations (malloc/free).
+ * @param node The MemoryManagement node specifying the action (allocate/deallocate).
+ */
+void LLVMVisitor::visit(MemoryManagement& node) {
+    if (node.action == MemoryManagement::ALLOCATE) {
+        node.size->accept(*this);
+        llvm::Value* sizeVal = currentValue;
+        Function* mallocFunc = module->getFunction("malloc");
+        if (!mallocFunc) {
+            llvm::Type* i64Type = llvm::Type::getInt64Ty(context);
+            llvm::FunctionType* mallocType =
+                llvm::FunctionType::get(llvm::Type::getInt8PtrTy(context), {i64Type}, false);
+            mallocFunc = Function::Create(mallocType, Function::ExternalLinkage, "malloc", module.get());
+        }
+        currentValue = builder.CreateCall(mallocFunc, {sizeVal}, "mallocCall");
+    } else if (node.action == MemoryManagement::DEALLOCATE) {
+        node.target->accept(*this);
+        llvm::Value* ptr = currentValue;
+        Function* freeFunc = module->getFunction("free");
+        if (!freeFunc) {
+            llvm::FunctionType* freeType =
+                llvm::FunctionType::get(llvm::Type::getVoidTy(context), {llvm::Type::getInt8PtrTy(context)}, false);
+            freeFunc = Function::Create(freeType, Function::ExternalLinkage, "free", module.get());
+        }
+        builder.CreateCall(freeFunc, {ptr});
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a return statement.
+ * @param node The ReturnStatement node containing the return value (can be nullptr).
+ */
+void LLVMVisitor::visit(ReturnStatement& node) {
+    if (node.returnValue) {
+        node.returnValue->accept(*this);
+        builder.CreateRet(currentValue);
+    } else {
+        builder.CreateRetVoid();
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a function call.
+ * @param node The FunctionCall node containing the callee and arguments.
+ */
+void LLVMVisitor::visit(FunctionCall& node) {
+    Function* callee = module->getFunction(node.functionName->name);
+    if (!callee) {
+        currentValue = nullptr;
+        return;
+    }
+    std::vector<llvm::Value*> args;
+    for (auto& arg : node.arguments) {
+        arg->accept(*this);
+        args.push_back(currentValue);
+    }
+    currentValue = builder.CreateCall(callee, args, "calltmp");
+}
+
+/**
+ * @todo
+ * @brief Base implementation for literal nodes.
+ * Specific literals are handled by their respective visitor methods.
+ * @param node The Literal node.
+ */
+void LLVMVisitor::visit(Literal& node) {
+    // Base implementation; specific literals have their own visitor.
+}
+
+/**
+ * @brief Generates LLVM IR for a boolean literal.
+ * @param node The BooleanLiteral node containing the boolean value.
+ */
+void LLVMVisitor::visit(BooleanLiteral& node) {
+    currentValue = ConstantInt::get(llvm::Type::getInt1Ty(context), node.value);
+}
+
+/**
+ * @brief Generates LLVM IR for a character literal.
+ * @param node The CharLiteral node containing the character value.
+ */
+void LLVMVisitor::visit(CharLiteral& node) {
+    currentValue = ConstantInt::get(llvm::Type::getInt8Ty(context), node.value);
+}
+
+/**
+ * @brief Generates LLVM IR for a string literal.
+ * @param node The StringLiteral node containing the string value.
+ */
+void LLVMVisitor::visit(StringLiteral& node) {
+    currentValue = builder.CreateGlobalStringPtr(node.value, "str");
+}
+
+/**
+ * @brief Generates LLVM IR for a binary expression.
+ * @param node The BinaryExpression node containing the operator and operands.
+ */
+void LLVMVisitor::visit(BinaryExpression& node) {
+    node.left->accept(*this);
+    llvm::Value* leftVal = currentValue;
+    node.right->accept(*this);
+    llvm::Value* rightVal = currentValue;
+
+    if (node.op == "+") {
+        currentValue = builder.CreateFAdd(leftVal, rightVal, "addtmp");
+    } else if (node.op == "-") {
+        currentValue = builder.CreateFSub(leftVal, rightVal, "subtmp");
+    } else if (node.op == "*") {
+        currentValue = builder.CreateFMul(leftVal, rightVal, "multmp");
+    } else if (node.op == "/") {
+        currentValue = builder.CreateFDiv(leftVal, rightVal, "divtmp");
+    } else if (node.op == "==") {
+        currentValue = builder.CreateFCmpOEQ(leftVal, rightVal, "eqtmp");
+    } else if (node.op == "!=") {
+        currentValue = builder.CreateFCmpONE(leftVal, rightVal, "netmp");
+    } else if (node.op == "<") {
+        currentValue = builder.CreateFCmpOLT(leftVal, rightVal, "lttmp");
+    } else if (node.op == "<=") {
+        currentValue = builder.CreateFCmpOLE(leftVal, rightVal, "letmp");
+    } else if (node.op == ">") {
+        currentValue = builder.CreateFCmpOGT(leftVal, rightVal, "gttmp");
+    } else if (node.op == ">=") {
+        currentValue = builder.CreateFCmpOGE(leftVal, rightVal, "getmp");
+    } else {
+        currentValue = nullptr; // Unsupported operator.
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a unary expression.
+ * @param node The UnaryExpression node containing the operator and operand.
+ */
+void LLVMVisitor::visit(UnaryExpression& node) {
+    node.operand->accept(*this);
+    llvm::Value* operandVal = currentValue;
+    if (node.op == "-") {
+        currentValue = builder.CreateFNeg(operandVal, "negtmp");
+    } else {
+        currentValue = nullptr; // Unsupported operator.
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for a primary expression.
+ * @param node The PrimaryExpression node containing the expression type.
+ */
+void LLVMVisitor::visit(PrimaryExpression& node) {
+    switch (node.exprType) {
+        case PrimaryExpression::IDENTIFIER:
+            node.identifier->accept(*this);
+            break;
+        case PrimaryExpression::LITERAL:
+            node.literal->accept(*this);
+            break;
+        case PrimaryExpression::PARENTHESIZED:
+            node.parenthesized->accept(*this);
+            break;
+        case PrimaryExpression::EXPRESSION_CALL:
+            node.functionCall->accept(*this);
+            break;
+        case PrimaryExpression::ARRAY_ACCESS:
+            node.arrayAccess->accept(*this);
+            break;
+        case PrimaryExpression::MEMBER_ACCESS:
+            node.memberAccess->accept(*this);
+            break;
+        case PrimaryExpression::CAST_EXPRESSION:
+            node.castExpression->accept(*this);
+            break;
+        case PrimaryExpression::TERNARY_EXPRESSION:
+            node.ternaryExpression->accept(*this);
+            break;
+        default:
+            currentValue = nullptr;
+            break;
+    }
+}
+
+/**
+ * @brief Generates LLVM IR for an array access expression.
+ * @param node The ArrayAccessExpression node containing the array and index.
+ */
+void LLVMVisitor::visit(ArrayAccessExpression& node) {
+    node.array->accept(*this);
+    llvm::Value* arrayPtr = currentValue;
+    node.index->accept(*this);
+    llvm::Value* indexVal = currentValue;
+
+    std::vector<llvm::Value*> indices;
+    indices.push_back(indexVal);
+    llvm::Type* elemType = arrayPtr->getType()->getPointerElementType();
+    llvm::Value* elemPtr = builder.CreateGEP(elemType, arrayPtr, indices, "arrayElem");
+    currentValue = builder.CreateLoad(elemType, elemPtr, "loadArrayElem");
+}
+
+/**
+ * @brief Generates LLVM IR for a ternary expression.
+ * @param node The TernaryExpression node containing the condition and branches.
+ */
+void LLVMVisitor::visit(TernaryExpression& node) {
+    Function* parentFunc = builder.GetInsertBlock()->getParent();
+    node.condition->accept(*this);
+    llvm::Value* condVal = currentValue;
+
+    BasicBlock* trueBB = BasicBlock::Create(context, "ternaryTrue", parentFunc);
+    BasicBlock* falseBB = BasicBlock::Create(context, "ternaryFalse", parentFunc);
+    BasicBlock* mergeBB = BasicBlock::Create(context, "ternaryMerge", parentFunc);
+
+    builder.CreateCondBr(condVal, trueBB, falseBB);
+
+    builder.SetInsertPoint(trueBB);
+    node.trueExpr->accept(*this);
+    llvm::Value* trueVal = currentValue;
+    if (!builder.GetInsertBlock()->getTerminator())
+        builder.CreateBr(mergeBB);
+
+    builder.SetInsertPoint(falseBB);
+    node.falseExpr->accept(*this);
+    llvm::Value* falseVal = currentValue;
+    if (!builder.GetInsertBlock()->getTerminator())
+        builder.CreateBr(mergeBB);
+
+    builder.SetInsertPoint(mergeBB);
+    PHINode* phi = builder.CreatePHI(trueVal->getType(), 2, "ternaryResult");
+    phi->addIncoming(trueVal, trueBB);
+    phi->addIncoming(falseVal, falseBB);
+    currentValue = phi;
+}
+
+/**
+ * @brief Generates LLVM IR for a cast expression.
+ * @param node The CastExpression node containing the target type and expression.
+ */
+void LLVMVisitor::visit(CastExpression& node) {
+    node.expression->accept(*this);
+    llvm::Value* exprVal = currentValue;
+    llvm::Type* targetLLVMType = typeToLLVM(*node.targetType);
+    currentValue = builder.CreateBitCast(exprVal, targetLLVMType, "casttmp");
+}
+
+/**
+ * @brief Generates LLVM IR for a member access expression.
+ * @param node The MemberAccessExpression node containing the object and member.
+ */
+void LLVMVisitor::visit(MemberAccessExpression& node) {
+    node.object->accept(*this);
+    llvm::Value* objectVal = currentValue;
+    // For a complete implementation, the member index should be retrieved and a GEP generated.
+    // Here, the object is returned without modification.
+    currentValue = objectVal;
+}
+
+} // namespace umbra

--- a/src/ast/LLVMVisitor.h
+++ b/src/ast/LLVMVisitor.h
@@ -1,0 +1,271 @@
+/*
+ * LLVMVisitor Header for Umbra Language Compiler
+ * Copyright (C) 2023 Free Software Foundation, Inc.
+ * 
+ * This file is part of the Umbra Compiler Project.
+ * Contributed by Ginozza (jsimancas@unimagdalena.edu.co).
+ * 
+ * The Umbra Compiler is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * The Umbra Compiler is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the Umbra Compiler; see the file COPYING.LIB. If
+ * not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef UMBRA_LLVM_VISITOR_H
+#define UMBRA_LLVM_VISITOR_H
+
+#include "ASTVisitor.h"
+#include <llvm/IR/Module.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <memory> // For std::unique_ptr
+#include <map>
+#include <string>
+
+namespace umbra {
+
+/**
+ * @brief Implements LLVM IR code generation from an AST.
+ * 
+ * The `LLVMVisitor` class inherits from `ASTVisitor` and provides methods to traverse
+ * an Abstract Syntax Tree (AST) and generate corresponding LLVM Intermediate
+ * Representation (IR) code. It uses LLVM's `IRBuilder` to dynamically construct IR
+ * instructions for various language constructs such as functions, variables, control
+ * flow, expressions, and memory management.
+ */
+class LLVMVisitor : public ASTVisitor {
+public:
+    /**
+     * @brief Constructs an LLVMVisitor object.
+     * 
+     * Initializes the LLVM context, module, and IRBuilder. This constructor sets up
+     * the necessary components for generating LLVM IR code.
+     */
+    LLVMVisitor();
+
+    /**
+     * @brief Destructor for LLVMVisitor.
+     * 
+     * Explicitly declared to match the exception specification of the base class
+     * `ASTVisitor`.
+     */
+    virtual ~LLVMVisitor() noexcept override = default;
+
+    /**
+     * @brief Visits a ProgramNode to generate LLVM IR for the entire program.
+     * @param node The ProgramNode representing the program structure.
+     */
+    void visit(ProgramNode& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a function definition.
+     * @param node The FunctionDefinition node containing the function's metadata.
+     */
+    void visit(FunctionDefinition& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a parameter list.
+     * @param node The ParameterList node containing the function's parameters.
+     */
+    void visit(ParameterList& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a type declaration.
+     * @param node The Type node representing a variable or function type.
+     */
+    void visit(Type& node) override;
+
+    /**
+     * @brief Generates LLVM IR for an identifier.
+     * @param node The Identifier node representing a variable or function name.
+     */
+    void visit(Identifier& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a generic statement.
+     * @param node The Statement node representing a single statement in the program.
+     */
+    void visit(Statement& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a variable declaration.
+     * @param node The VariableDeclaration node containing the variable's metadata.
+     */
+    void visit(VariableDeclaration& node) override;
+
+    /**
+     * @brief Generates LLVM IR for an assignment statement.
+     * @param node The AssignmentStatement node containing the target and value.
+     */
+    void visit(AssignmentStatement& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a conditional statement (if-else).
+     * @param node The Conditional node containing the condition and branches.
+     */
+    void visit(Conditional& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a loop construct.
+     * @param node The Loop node containing the condition and body.
+     */
+    void visit(Loop& node) override;
+
+    /**
+     * @brief Generates LLVM IR for memory management operations (malloc/free).
+     * @param node The MemoryManagement node specifying the action (allocate/deallocate).
+     */
+    void visit(MemoryManagement& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a return statement.
+     * @param node The ReturnStatement node containing the return value (can be nullptr).
+     */
+    void visit(ReturnStatement& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a function call.
+     * @param node The FunctionCall node containing the callee and arguments.
+     */
+    void visit(FunctionCall& node) override;
+
+    /**
+     * @brief Base implementation for literal nodes.
+     * Specific literals are handled by their respective visitor methods.
+     * @param node The Literal node.
+     */
+    void visit(Literal& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a numeric literal.
+     * @param node The NumericLiteral node containing the numeric value.
+     */
+    void visit(NumericLiteral& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a boolean literal.
+     * @param node The BooleanLiteral node containing the boolean value.
+     */
+    void visit(BooleanLiteral& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a character literal.
+     * @param node The CharLiteral node containing the character value.
+     */
+    void visit(CharLiteral& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a string literal.
+     * @param node The StringLiteral node containing the string value.
+     */
+    void visit(StringLiteral& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a binary expression.
+     * @param node The BinaryExpression node containing the operator and operands.
+     */
+    void visit(BinaryExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a unary expression.
+     * @param node The UnaryExpression node containing the operator and operand.
+     */
+    void visit(UnaryExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a primary expression.
+     * @param node The PrimaryExpression node containing the expression type.
+     */
+    void visit(PrimaryExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for an array access expression.
+     * @param node The ArrayAccessExpression node containing the array and index.
+     */
+    void visit(ArrayAccessExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a ternary expression.
+     * @param node The TernaryExpression node containing the condition and branches.
+     */
+    void visit(TernaryExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a cast expression.
+     * @param node The CastExpression node containing the target type and expression.
+     */
+    void visit(CastExpression& node) override;
+
+    /**
+     * @brief Generates LLVM IR for a member access expression.
+     * @param node The MemberAccessExpression node containing the object and member.
+     */
+    void visit(MemberAccessExpression& node) override;
+
+    /**
+     * @brief Retrieves the generated LLVM module.
+     * 
+     * This method returns the LLVM module containing the generated IR code. After
+     * calling this method, the ownership of the module is transferred to the caller.
+     * 
+     * @return std::unique_ptr<llvm::Module> The generated LLVM module.
+     */
+    std::unique_ptr<llvm::Module> getModule() { return std::move(module); }
+
+private:
+    /**
+     * @brief The LLVM module containing the generated IR code.
+     */
+    std::unique_ptr<llvm::Module> module;
+
+    /**
+     * @brief The LLVM context used to create types and values.
+     */
+    llvm::LLVMContext context;
+
+    /**
+     * @brief The IRBuilder for dynamically constructing LLVM IR instructions.
+     */
+    llvm::IRBuilder<> builder;
+
+    /**
+     * @brief The current value generated during the traversal of a node.
+     */
+    llvm::Value* currentValue = nullptr;
+
+    /**
+     * @brief Symbol table to store variables and their memory addresses.
+     */
+    std::map<std::string, llvm::Value*> symbolTable;
+
+    /**
+     * @brief Converts Umbra language types to LLVM types.
+     * 
+     * This helper function maps types from the Umbra language to their equivalent
+     * LLVM types.
+     * 
+     * @param type The Umbra language type.
+     * @return llvm::Type* The equivalent LLVM type.
+     */
+    llvm::Type* typeToLLVM(Type& type);
+
+    /**
+     * @brief Creates runtime checks required for the program.
+     * 
+     * This method generates any necessary runtime checks, such as bounds checking
+     * for arrays or null pointer checks.
+     */
+    void createRuntimeChecks();
+};
+
+} // namespace umbra
+
+#endif // UMBRA_LLVM_VISITOR_H

--- a/src/ast/Nodes.h
+++ b/src/ast/Nodes.h
@@ -1,6 +1,3 @@
-
-
-
 #ifndef AST_NODES_HPP
 #define AST_NODES_HPP
 
@@ -8,6 +5,7 @@
 #include <vector>
 #include <memory>
 #include "ASTNode.h"
+#include "ASTVisitor.h"
 
 namespace umbra {
 
@@ -24,14 +22,14 @@ namespace umbra {
     // Expression base class
     class Expression : public ASTNode {
     public:
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override = 0;
     };
 
     // Program node
     class ProgramNode : public ASTNode {
     public:
         ProgramNode(std::vector<std::unique_ptr<FunctionDefinition>> functions);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::vector<std::unique_ptr<FunctionDefinition>> functions;
     };
 
@@ -40,7 +38,7 @@ namespace umbra {
     public:
         FunctionDefinition(std::unique_ptr<Identifier> name, std::unique_ptr<ParameterList> parameters,
             std::unique_ptr<Type> returnType, std::vector<std::unique_ptr<Statement>> body);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Identifier> name;
         std::unique_ptr<ParameterList> parameters;
         std::unique_ptr<Type> returnType;
@@ -51,7 +49,7 @@ namespace umbra {
     class ParameterList : public ASTNode {
     public:
         ParameterList(std::vector<std::pair<std::unique_ptr<Type>, std::unique_ptr<Identifier>>> parameters);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::vector<std::pair<std::unique_ptr<Type>, std::unique_ptr<Identifier>>> parameters;
     };
 
@@ -59,7 +57,7 @@ namespace umbra {
     class Type : public ASTNode {
     public:
         Type(std::string baseType, int arrayDimensions = 0);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::string baseType; // e.g., int, float, etc.
         int arrayDimensions = 0; // Number of dimensions if it's an array
     };
@@ -68,14 +66,14 @@ namespace umbra {
     class Identifier : public Expression {
     public:
         Identifier(std::string name);
-
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::string name;
     };
 
     // Statement base class
     class Statement : public ASTNode {
     public:
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
     };
 
     // Variable declaration node
@@ -83,7 +81,7 @@ namespace umbra {
     public:
         VariableDeclaration(std::unique_ptr<Type> type, std::unique_ptr<Identifier> name,
             std::unique_ptr<Expression> initializer);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Type> type;
         std::unique_ptr<Identifier> name;
         std::unique_ptr<Expression> initializer;
@@ -93,7 +91,7 @@ namespace umbra {
     class AssignmentStatement : public Statement {
     public:
         AssignmentStatement(std::unique_ptr<Identifier> target, std::unique_ptr<Expression> value);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Identifier> target;
         std::unique_ptr<Expression> index; // For array assignment
         std::unique_ptr<Expression> value;
@@ -104,7 +102,7 @@ namespace umbra {
     public:
         Conditional(std::vector<std::pair<std::unique_ptr<Expression>, std::vector<std::unique_ptr<Statement>>>> branches,
             std::vector<std::unique_ptr<Statement>> elseBranch);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         struct Branch {
             std::unique_ptr<Expression> condition;
             std::vector<std::unique_ptr<Statement>> body;
@@ -118,7 +116,7 @@ namespace umbra {
     class Loop : public Statement {
     public:
         Loop(std::unique_ptr<Expression> condition, std::vector<std::unique_ptr<Statement>> body);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Expression> condition;
         std::vector<std::unique_ptr<Statement>> body;
         bool isRepeatTimes = false; // true if "repeat N times", false if "repeat if"
@@ -130,7 +128,7 @@ namespace umbra {
         enum ActionType { ALLOCATE, DEALLOCATE };
         MemoryManagement(ActionType action, std::unique_ptr<Type> type, std::unique_ptr<Expression> size,
             std::unique_ptr<Identifier> target);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         ActionType action;
         std::unique_ptr<Type> type;
         std::unique_ptr<Expression> size; // For allocation
@@ -141,7 +139,7 @@ namespace umbra {
     class ReturnStatement : public Statement {
     public:
         ReturnStatement(std::unique_ptr<Expression> returnValue);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Expression> returnValue;
     };
 
@@ -149,7 +147,7 @@ namespace umbra {
     class BinaryExpression : public Expression {
     public:
         BinaryExpression(std::string op, std::unique_ptr<Expression> left, std::unique_ptr<Expression> right);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::string op; // Operator (e.g., +, -, *, etc.)
         std::unique_ptr<Expression> left;
         std::unique_ptr<Expression> right;
@@ -159,7 +157,7 @@ namespace umbra {
     class UnaryExpression : public Expression {
     public:
         UnaryExpression(std::string op, std::unique_ptr<Expression> operand);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::string op; // Operator (e.g., ptr, ref, access)
         std::unique_ptr<Expression> operand;
     };
@@ -167,7 +165,7 @@ namespace umbra {
     // Primary expression node
     class PrimaryExpression : public Expression {
     public:
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
 
         enum Type { 
             IDENTIFIER, 
@@ -205,7 +203,7 @@ namespace umbra {
     class Literal : public ASTNode {
     public:
 
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         enum Type { INTEGER, FLOAT, BOOLEAN, CHAR, STRING } literalType;
 
         Literal(std::string value);
@@ -217,7 +215,7 @@ namespace umbra {
     class FunctionCall : public Expression {
     public:
         FunctionCall(std::unique_ptr<Identifier> functionName, std::vector<std::unique_ptr<Expression>> arguments);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Identifier> functionName;
         std::vector<std::unique_ptr<Expression>> arguments;
     };
@@ -226,7 +224,7 @@ namespace umbra {
     class NumericLiteral : public Literal {
     public:
         NumericLiteral(double value);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         double value;
     };
 
@@ -234,7 +232,7 @@ namespace umbra {
     class BooleanLiteral : public Literal {
     public:
         BooleanLiteral(bool value);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         bool value;
     };
 
@@ -242,7 +240,7 @@ namespace umbra {
     class CharLiteral : public Literal {
     public:
         CharLiteral(char value);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         char value;
     };
 
@@ -250,7 +248,7 @@ namespace umbra {
     class StringLiteral : public Literal {
     public:
         StringLiteral(std::string value);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::string value;
     };
 
@@ -259,7 +257,7 @@ namespace umbra {
     public:
         ArrayAccessExpression(std::unique_ptr<Expression> array, 
                             std::unique_ptr<Expression> index);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Expression> array;
         std::unique_ptr<Expression> index;
     };
@@ -270,7 +268,7 @@ namespace umbra {
         TernaryExpression(std::unique_ptr<Expression> condition,
                         std::unique_ptr<Expression> trueExpr,
                         std::unique_ptr<Expression> falseExpr);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Expression> condition;
         std::unique_ptr<Expression> trueExpr;
         std::unique_ptr<Expression> falseExpr;
@@ -281,7 +279,7 @@ namespace umbra {
     public:
         CastExpression(std::unique_ptr<Type> targetType,
                     std::unique_ptr<Expression> expression);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Type> targetType;
         std::unique_ptr<Expression> expression;
     };
@@ -290,7 +288,7 @@ namespace umbra {
     public:
         MemberAccessExpression(std::unique_ptr<Expression> object,
                             std::unique_ptr<Identifier> member);
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override { visitor.visit(*this); }
         std::unique_ptr<Expression> object;
         std::unique_ptr<Identifier> member;
     };


### PR DESCRIPTION
- Implementa `ASTVisitor` para recorrer todos los nodos del AST.
- Añade `LLVMVisitor` con capacidades básicas de generación de IR.
- Incluye utilidad de conversión de tipos (`typeToLLVM`) para mapear tipos del lenguaje a LLVM.
- Establece infraestructura para generación de IR de LLVM y futuro manejo seguro de memoria.
- Añade una serie de tareas pendientes (TODOs) a implementar para el AST.

También introduzco un formato de licencia individual de los archivos para el reconocimiento de las contribuciones en el código.

Vista previa disponible en mi fork: [@ginozza/umbra](https://github.com/ginozza/Umbra/blob/main/src/ast/LLVMVisitor.cpp)