### PR TITLE
 fix(lexer): Corrección en el autómata de números y mejoras en documentación y pruebas

### DIFF
--- a/src/lexer/Lexer.h
+++ b/src/lexer/Lexer.h
@@ -9,62 +9,226 @@
 
 namespace umbra {
 
+/**
+ * @brief Clase analizador léxico que convierte texto fuente en tokens
+ * 
+ * El Lexer es responsable de analizar el texto fuente carácter por carácter
+ * y generar una secuencia de tokens que representan los elementos léxicos
+ * del lenguaje (números, identificadores, operadores, etc.).
+ */
 class Lexer {
   public:
+    /**
+     * @brief Estructura que representa un token léxico
+     */
     struct Token {
-        TokenType type;
-        std::string lexeme;
-        int line;
-        int column;
+        TokenType type;      ///< Tipo del token
+        std::string lexeme;  ///< Texto literal del token
+        int line;           ///< Línea donde se encontró el token
+        int column;         ///< Columna donde se encontró el token
 
+        /**
+         * @brief Constructor de Token
+         * @param t Tipo del token
+         * @param l Lexema del token
+         * @param ln Línea donde se encontró
+         * @param col Columna donde se encontró
+         */
         Token(TokenType t, std::string l, int ln, int col)
             : type(t), lexeme(std::move(l)), line(ln), column(col) {}
     };
-    TokenManager tokenManager;
+    TokenManager tokenManager;  ///< Gestor de tokens
 
+    /**
+     * @brief Constructor que inicializa el Lexer con texto fuente
+     * @param source Texto fuente a analizar
+     */
     Lexer(const std::string &source);
+
+    /**
+     * @brief Constructor que inicializa el Lexer con texto fuente y un gestor de errores externo
+     * @param source Texto fuente a analizar
+     * @param externalErrorManager Gestor de errores externo
+     */
     Lexer(const std::string &source, ErrorManager &externalErrorManager);
+
+    /**
+     * @brief Analiza el texto fuente y genera una lista de tokens
+     * @return Vector de tokens generados
+     */
     std::vector<Token> tokenize();
+
+    /**
+     * @brief Obtiene el gestor de errores actual
+     * @return Referencia constante al gestor de errores
+     */
     const ErrorManager &getErrorManager() const { return *errorManager; }
+
+    /**
+     * @brief Reinicia el estado del lexer
+     */
     void reset();
+
+    /**
+     * @brief Observa el siguiente token sin consumirlo
+     * @return Token siguiente en la secuencia
+     */
     Token peekToken();
+
+    /**
+     * @brief Obtiene y consume el siguiente token
+     * @return Token siguiente en la secuencia
+     */
     Token getNextToken();
+
+    /**
+     * @brief Obtiene el texto fuente actual
+     * @return String con el texto fuente
+     */
     std::string getSource();
   private:
-    std::string source;
-    std::unique_ptr<ErrorManager> internalErrorManager;
-    ErrorManager *errorManager;
-    std::vector<Token> tokens;
-    char lastChar = ' ';
-    enum class State { Start, Integer, Decimal, NotationNumber, Acceptance, Rejection };
-    // std::unordered_map<std::string, TokenType> keywords;
-    int current = 0;
-    int line = 1;
-    int start = 0;
-    int column = 1;
-    State state=State::Start;
+    std::string source;                              ///< Texto fuente a analizar
+    std::unique_ptr<ErrorManager> internalErrorManager;  ///< Gestor de errores interno
+    ErrorManager *errorManager;                      ///< Puntero al gestor de errores actual
+    std::vector<Token> tokens;                       ///< Lista de tokens generados
+    char lastChar = ' ';                            ///< Último carácter leído
+    
+    /**
+     * @brief Estados del autómata para el reconocimiento de números
+     */
+    enum class State { 
+        Start,          ///< Estado inicial
+        Integer,        ///< Reconociendo parte entera
+        Decimal,        ///< Reconociendo parte decimal
+        NotationNumber, ///< Reconociendo notación científica
+        Acceptance,     ///< Estado de aceptación
+        Rejection       ///< Estado de rechazo
+    };
 
+    int current = 0;    ///< Posición actual en el texto fuente
+    int line = 1;       ///< Línea actual
+    int start = 0;      ///< Inicio del token actual
+    int column = 1;     ///< Columna actual
+    State state=State::Start;  ///< Estado actual del autómata
+
+    /**
+     * @brief Avanza al siguiente carácter del texto fuente
+     * @return Carácter actual
+     */
     char advance();
+
+    /**
+     * @brief Verifica si se llegó al final del texto fuente
+     * @return true si no hay más caracteres que leer
+     */
     bool isAtEnd() const;
+
+    /**
+     * @brief Observa el siguiente carácter sin consumirlo
+     * @return Siguiente carácter o '\0' si es fin de archivo
+     */
     char peek() const;
+
+    /**
+     * @brief Observa el carácter después del siguiente sin consumirlo
+     * @return Carácter después del siguiente o '\0' si es fin de archivo
+     */
     char peekNext() const;
+
+    /**
+     * @brief Intenta hacer match con un carácter esperado
+     * @param expected Carácter esperado
+     * @return true si hay match y se consumió el carácter
+     */
     bool match(char expected);
+
+    /**
+     * @brief Agrega un nuevo token a la lista
+     * @param type Tipo del token
+     */
     void addToken(TokenType type);
+
+    /**
+     * @brief Agrega un nuevo token a la lista con un lexema específico
+     * @param type Tipo del token
+     * @param lexeme Lexema del token
+     */
     void addToken(TokenType type, const std::string &lexeme);
+
+    /**
+     * @brief Procesa una cadena de texto
+     */
     void string();
+
+    /**
+     * @brief Procesa un número (entero, decimal o notación científica)
+     */
     void number();
+
+    /**
+     * @brief Procesa un carácter literal
+     */
     void charliteral();
+
+    /**
+     * @brief Procesa un identificador
+     */
     void identifier();
+
+    /**
+     * @brief Verifica si un carácter es una letra
+     * @param c Carácter a verificar
+     * @return true si es una letra
+     */
     bool isAlpha(char c) const;
+
+    /**
+     * @brief Verifica si un carácter es alfanumérico
+     * @param c Carácter a verificar
+     * @return true si es alfanumérico
+     */
     bool isAlphaNumeric(char c) const;
+
+    /**
+     * @brief Verifica si un carácter es un dígito
+     * @param c Carácter a verificar
+     * @return true si es un dígito
+     */
     bool isDigit(char c) const;
+
+    /**
+     * @brief Verifica si un carácter es un signo de operación
+     * @param c Carácter a verificar
+     * @return true si es un signo de operación
+     */
     bool isSing(char c) const;
+
+    /**
+     * @brief Verifica si un carácter es un espacio en blanco
+     * @param c Carácter a verificar
+     * @return true si es un espacio en blanco
+     */
     bool isWhitespace(char c) const;
-    //void scanToken();
-    //void handleIdentifierOrKeyword();
+
+    /**
+     * @brief Verifica si un carácter es un espacio en blanco (incluye tab)
+     * @param c Carácter a verificar
+     * @return true si es un espacio en blanco
+     */
     bool isBlankSpace(char c) const;
-    bool isBinary(char c) ;
-    void errorMessage(char c); // error unexpected character c
+
+    /**
+     * @brief Verifica y procesa un número binario
+     * @param c Carácter inicial
+     * @return true si se procesó un número binario válido
+     */
+    bool isBinary(char c);
+
+    /**
+     * @brief Genera un mensaje de error para un carácter inesperado
+     * @param c Carácter que causó el error
+     */
+    void errorMessage(char c);
 };
 
 } // namespace umbra

--- a/tests/lexer/lexer_test.cpp
+++ b/tests/lexer/lexer_test.cpp
@@ -232,6 +232,32 @@ TEST(LexerTest, TokenizeFunctionWithComparison) {
     EXPECT_EQ(tokens[18].type, TokenType::TOK_LESS);      // 'less_than'
 }
 
+// Prueba de expresiones sin espacios
+TEST(LexerTest, TokenizeExpressionsWithoutSpaces) {
+    std::string source = "int result = (1+2)*3";
+    Lexer lexer(source);
+    std::vector<Lexer::Token> tokens = lexer.tokenize();
+
+    std::cout << "\nTokens generados:" << std::endl;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        std::cout << i << ": " << tokens[i].lexeme << std::endl;
+    }
+
+    ASSERT_EQ(tokens.size(), 11); // 10 tokens + EOF
+
+    EXPECT_EQ(tokens[0].type, TokenType::TOK_INT);           // 'int'
+    EXPECT_EQ(tokens[1].type, TokenType::TOK_IDENTIFIER);    // 'result'
+    EXPECT_EQ(tokens[2].type, TokenType::TOK_ASSIGN);        // '='
+    EXPECT_EQ(tokens[3].type, TokenType::TOK_LEFT_PAREN);    // '('
+    EXPECT_EQ(tokens[4].type, TokenType::TOK_NUMBER);        // '1'
+    EXPECT_EQ(tokens[5].type, TokenType::TOK_ADD);           // '+'
+    EXPECT_EQ(tokens[6].type, TokenType::TOK_NUMBER);        // '2'
+    EXPECT_EQ(tokens[7].type, TokenType::TOK_RIGHT_PAREN);   // ')'
+    EXPECT_EQ(tokens[8].type, TokenType::TOK_MULT);          // '*'
+    EXPECT_EQ(tokens[9].type, TokenType::TOK_NUMBER);        // '3'
+    EXPECT_EQ(tokens[10].type, TokenType::TOK_EOF);          // EOF
+}
+
 } // namespace umbra
 
 } // namespace umbra


### PR DESCRIPTION
Cambios:

- Corrige error en el autómata del Lexer al reconocer números, se creía que el error era por el reconocimiento de espacios pero esto era  falso, el problema era que no reconocía correctamente el caracter `)` y final de fuente. 
- Añade documentación en `Lexer.h` y `Lexer.cpp`.
- Agrega prueba unitaria para tokenizar expresiones sin espacios y comprobar la solución del error.