### PR TITLE
feat: add support for repeat and for loops

### DIFF
--- a/examples/for.umbra
+++ b/examples/for.umbra
@@ -1,0 +1,5 @@
+func start () -> void {
+    repeat 6 times {
+        print("Hola mundo\n")
+    }
+}

--- a/src/ast/ASTVisitor.cpp
+++ b/src/ast/ASTVisitor.cpp
@@ -426,6 +426,11 @@ namespace umbra {
         deep--;
     }
 
+    /**
+     * @brief Process a repeat-times loop statement node
+     * @param node The repeat-times node to visit
+     * @details Prints the hierarchical structure of a 'repeat n times' loop, showing the iteration count expression and all body statements with proper indentation to reflect nesting levels.
+     */
     void PrintASTVisitor::visit(RepeatTimesStatement& node) {
         indent();
         std::cout << "Repeat-Times Loop:" << std::endl;
@@ -449,6 +454,11 @@ namespace umbra {
         deep--;
     }
 
+    /**
+     * @brief Process a repeat-if conditional loop statement node
+     * @param node The repeat-if node to visit
+     * @details Prints the complete structure of a 'repeat if' loop, displaying the condition expression and all body statements while maintaining visual hierarchy through indentation.
+     */
     void PrintASTVisitor::visit(RepeatIfStatement& node){
         indent();
         std::cout << "Repeat-If Loop:" << std::endl;

--- a/src/ast/ASTVisitor.cpp
+++ b/src/ast/ASTVisitor.cpp
@@ -25,7 +25,9 @@
  * @namespace umbra
  */
 #include"ASTVisitor.h"
+#include "Nodes.h"
 #include <iostream>
+#include <iterator>
 
 namespace umbra {
 
@@ -421,6 +423,52 @@ namespace umbra {
             indent();
             std::cout << "(no return value)" << std::endl;
         }
+        deep--;
+    }
+
+    void PrintASTVisitor::visit(RepeatTimesStatement& node) {
+        indent();
+        std::cout << "Repeat-Times Loop:" << std::endl;
+
+        deep++;
+
+        indent();
+        std::cout << "Iterations:" << std::endl;
+        deep++;
+        node.times->accept(*this);
+        deep--;
+
+        indent();
+        std::cout << "Body:" << std::endl;
+        deep++;
+        for (const auto& statement : node.body) {
+            statement->accept(*this);
+        }
+        deep--;
+
+        deep--;
+    }
+
+    void PrintASTVisitor::visit(RepeatIfStatement& node){
+        indent();
+        std::cout << "Repeat-If Loop:" << std::endl;
+
+        deep++;
+
+        indent();
+        std::cout << "Condition:" << std::endl;
+        deep++;
+        node.condition->accept(*this);
+        deep--;
+
+        indent();
+        std::cout << "Body:" << std::endl;  
+        deep++;
+        for (const auto& statement : node.body) {
+            statement->accept(*this);
+        }
+        deep--;
+
         deep--;
     }
 }

--- a/src/ast/ASTVisitor.h
+++ b/src/ast/ASTVisitor.h
@@ -134,6 +134,18 @@ public:
      * @param node The return expression node to visit
      */
     virtual void visit(ReturnExpression& node) = 0;
+
+    /**
+     * @brief Visit method for RepeatTimesStatement
+     * @param node The return repeat statement node to visit
+     */
+    virtual void visit(RepeatTimesStatement& node) = 0;
+
+    /**
+     * @brief Visit method for RepeatIfStatement
+     * @param node The return repeat statement node to visit
+     */
+    virtual void visit(RepeatIfStatement& node) = 0;
 };
 
 /**
@@ -168,6 +180,8 @@ class BaseVisitor : public ASTVisitor {
         void visit(NumericLiteral &node) override {}
         void visit(ReturnExpression& node) override {}
         // Add any other visit methods required by ASTVisitor
+        void visit(RepeatTimesStatement& node) override {}
+        void visit(RepeatIfStatement& node) override {}
 };
 
 
@@ -285,6 +299,18 @@ public:
      * @param node The return expression node to process
      */
     void visit(ReturnExpression& node) override;
+
+    /**
+     * @brief Visit implementation for RepeatTimesStatement
+     * @param node The return repeat expression node to process
+     */
+    void visit(RepeatTimesStatement& node) override;
+
+    /**
+     * @brief Visit implementation for RepeatIfStatement
+     * @param node The return repeat expression node to process
+     */
+    void visit(RepeatIfStatement& node) override;
 };
 
 } // namespace umbra

--- a/src/ast/Nodes.cpp
+++ b/src/ast/Nodes.cpp
@@ -7,6 +7,7 @@
 
 #include "Nodes.h"
 #include "ASTVisitor.h"
+#include <memory>
 
 namespace umbra {
 
@@ -153,6 +154,22 @@ namespace umbra {
     MemoryManagement::MemoryManagement(ActionType action, std::unique_ptr<Type> type, 
         std::unique_ptr<Expression> size, std::unique_ptr<Identifier> target) 
         : action(action), type(std::move(type)), size(std::move(size)), target(std::move(target)) {}
+
+    /**
+     * @brief Constructs a repeat times loop statement node
+     * @param times Loop times continuation
+     * @param body Vector of loop body statements
+     */
+    RepeatTimesStatement::RepeatTimesStatement(std::unique_ptr<Expression> times, std::vector<std::unique_ptr<Statement>> body)
+        : times(std::move(times)), body(std::move(body)) {} 
+
+    /**
+     * @brief Constructs a repeat if loop statement node
+     * @param condition Loop continuation condition
+     * @param body Vector of loop body statements
+     */
+    RepeatIfStatement::RepeatIfStatement(std::unique_ptr<Expression> condition, std::vector<std::unique_ptr<Statement>> body)
+        : condition(std::move(condition)), body(std::move(body)) {} 
 
     /**
      * @brief Constructs a return statement node

--- a/src/ast/Nodes.cpp
+++ b/src/ast/Nodes.cpp
@@ -163,6 +163,10 @@ namespace umbra {
     RepeatTimesStatement::RepeatTimesStatement(std::unique_ptr<Expression> times, std::vector<std::unique_ptr<Statement>> body)
         : times(std::move(times)), body(std::move(body)) {} 
 
+    void RepeatTimesStatement::accept(ASTVisitor &visitor){
+        visitor.visit(*this);
+    }
+    
     /**
      * @brief Constructs a repeat if loop statement node
      * @param condition Loop continuation condition

--- a/src/ast/Nodes.cpp
+++ b/src/ast/Nodes.cpp
@@ -174,7 +174,11 @@ namespace umbra {
      */
     RepeatIfStatement::RepeatIfStatement(std::unique_ptr<Expression> condition, std::vector<std::unique_ptr<Statement>> body)
         : condition(std::move(condition)), body(std::move(body)) {} 
-
+    
+    void RepeatIfStatement::accept(ASTVisitor &visitor){
+        visitor.visit(*this);
+    }
+       
     /**
      * @brief Constructs a return statement node
      * @param returnValue Expression to return

--- a/src/ast/Nodes.h
+++ b/src/ast/Nodes.h
@@ -160,7 +160,7 @@ namespace umbra {
     public:
         RepeatTimesStatement(std::unique_ptr<Expression> times,
                             std::vector<std::unique_ptr<Statement>> body);  
-        void accept(ASTVisitor& visitor) override {}
+        void accept(ASTVisitor& visitor) override;
         std::unique_ptr<Expression> times;
         std::vector<std::unique_ptr<Statement>> body;
     };
@@ -170,7 +170,7 @@ namespace umbra {
     public:
         RepeatIfStatement(std::unique_ptr<Expression> condition,
                             std::vector<std::unique_ptr<Statement>> body);
-        void accept(ASTVisitor& visitor) override {}            
+        void accept(ASTVisitor& visitor) override;           
         std::unique_ptr<Expression> condition;
         std::vector<std::unique_ptr<Statement>> body;
     };

--- a/src/ast/Nodes.h
+++ b/src/ast/Nodes.h
@@ -155,6 +155,26 @@ namespace umbra {
         std::unique_ptr<Identifier> target; // For deallocation
     };
 
+    // Repeat times statement node (For)
+    class RepeatTimesStatement : public Statement {
+    public:
+        RepeatTimesStatement(std::unique_ptr<Expression> times,
+                            std::vector<std::unique_ptr<Statement>> body);  
+        void accept(ASTVisitor& visitor) override {}
+        std::unique_ptr<Expression> times;
+        std::vector<std::unique_ptr<Statement>> body;
+    };
+    
+    // Repeat if statement node (While)
+    class RepeatIfStatement : public Statement {
+    public:
+        RepeatIfStatement(std::unique_ptr<Expression> condition,
+                            std::vector<std::unique_ptr<Statement>> body);
+        void accept(ASTVisitor& visitor) override {}            
+        std::unique_ptr<Expression> condition;
+        std::vector<std::unique_ptr<Statement>> body;
+    };
+
     // Return statement node
     class ReturnExpression : public Expression{
     public:
@@ -321,6 +341,8 @@ namespace umbra {
         std::unique_ptr<Expression> object;
         std::unique_ptr<Identifier> member;
     };
+
+    
 
 };
 

--- a/src/codegen/visitors/CodegenVisitor.h
+++ b/src/codegen/visitors/CodegenVisitor.h
@@ -21,6 +21,9 @@ namespace umbra{
 
             //literals
             void visit(umbra::StringLiteral& node) override;
+            void visit(umbra::NumericLiteral& node) override;
+            void visit(umbra::BooleanLiteral& node) override;
+            void visit(umbra::CharLiteral& node) override;
 
             //expressions
             void visit(umbra::ExpressionStatement& node) override;
@@ -28,7 +31,8 @@ namespace umbra{
 
             //statements
             void visit(umbra::FunctionCall& node) override;
-
+            void visit(umbra::RepeatTimesStatement& node) override;
+            void visit(umbra::RepeatIfStatement& node) override;
 
             //top_level
             void visit(umbra::FunctionDefinition& node) override;

--- a/src/parser/Parser.h
+++ b/src/parser/Parser.h
@@ -60,6 +60,8 @@ namespace umbra {
         std::unique_ptr<Expression> parseParams();
         std::unique_ptr<ReturnExpression> parseReturnExpression();
         std::unique_ptr<Literal> parseLiteral();
+        std::unique_ptr<RepeatTimesStatement> parseRepeatTimesStatement();
+        std::unique_ptr<RepeatIfStatement> parseRepeatIfStatement();
         
         //void expectToken(TokenType expectedType);
         void error(const std::string& message, int line, int column);


### PR DESCRIPTION
Adds support for repeat loops and for loops for the Umbra Compiler.

- Parser: implemented syntax for `repeat n times` and `repeat if`.
- AST: added nodes `RepeatTimesStatement` and `RepeatIfStatement` with visitor support.
- Codegen: added code generation for for loops. TODO: implement while loops.
- Tests: added example of for loop.

See commits for details.