### PR TITLE
Implementar método stripBOM

### DIFF
--- a/src/preprocessor/Sanitize.cpp
+++ b/src/preprocessor/Sanitize.cpp
@@ -1,9 +1,26 @@
 #include "umbra/preprocessor/Sanitize.h"
-
 #include<string>
+
 namespace umbra {
 
-    std::string Sanitizer::convertInternalEncoding(std::string& inputBytes){
+    std::string Sanitizer::convertInternalEncoding(std::string& inputBytes) {
 
+    }
+
+    std::string Sanitizer::stripBOM(std::string& inputBytes) {
+        if (inputBytes.size() >= 3 &&
+            static_cast<unsigned char>(inputBytes[0]) == 0xEF &&
+            static_cast<unsigned char>(inputBytes[1]) == 0xBB &&
+            static_cast<unsigned char>(inputBytes[2]) == 0xBF) {
+            inputBytes.erase(0, 3);
+        }
+        else if (inputBytes.size() >= 2 &&
+            ((static_cast<unsigned char>(inputBytes[0]) == 0xFF &&
+            static_cast<unsigned char>(inputBytes[1]) == 0xFE) ||
+            (static_cast<unsigned char>(inputBytes[0]) == 0xFE &&
+            static_cast<unsigned char>(inputBytes[1]) == 0xFF))) {
+            inputBytes.erase(0, 2);
+        }
+        return inputBytes;
     }
 }


### PR DESCRIPTION
Implementa el método stripBOM para eliminar el Byte Order Mark del input.

Solo detecta y elimina el BOM de UTF-8 y UTF-16 (BE y LE). 