### PR TITLE
Implements method normalizeEncondign()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,19 @@ add_library(umbra_lexer ${LEXER_SOURCES})
 target_link_libraries(umbra_lexer PUBLIC umbra_error)
 target_include_directories(umbra_lexer PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
+# FIND UTF8PROC
+find_library(UTF8PROC_LIB utf8proc)
+
+if(UTF8PROC_LIB)
+    message(STATUS "Found utf8proc at: ${UTF8PROC_LIB}")
+    target_link_libraries(umbra_lexer PUBLIC ${UTF8PROC_LIB})
+else()
+    message(FATAL_ERROR "utf8proc not found. Install it with: sudo apt install libutf8proc-dev")
+endif()
+
+target_link_libraries(umbra_lexer PUBLIC umbra_error)
+target_include_directories(umbra_lexer PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
 # PARSER
 file(GLOB_RECURSE PARSER_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/parser/*.cpp)
 add_library(umbra_parser ${PARSER_SOURCES})

--- a/SETUP.md
+++ b/SETUP.md
@@ -11,14 +11,14 @@ El proyecto requiere **LLVM** para su compilación. A continuación te mostramos
 ### Instalación de Dependencias
 #### Linux
 
-> Dependencias principales: LLVM 20, Boost Program Options, GoogleTest, CMake y un compilador C++17.
+> Dependencias principales: LLVM 20, Boost Program Options, GoogleTest, utf8proc, CMake y un compilador C++17.
 
 ##### Distribuciones basadas en Debian (Ubuntu, etc.)
 
-1) CMake, toolchain y Boost Program Options:
+1) CMake, toolchain, Boost Program Options y utf8proc:
 ```bash
 sudo apt update
-sudo apt install -y cmake g++ build-essential libboost-program-options-dev
+sudo apt install -y cmake g++ build-essential libboost-program-options-dev libutf8proc-dev
 ```
 
 2) LLVM 20 (desde apt.llvm.org):
@@ -44,9 +44,9 @@ sudo cmake --install /usr/src/googletest/build
 
 ##### Distribuciones basadas en Arch (Arch, Manjaro)
 
-1) CMake, toolchain y Boost:
+1) CMake, toolchain, Boost y utf8proc:
 ```bash
-sudo pacman -Syu --needed cmake base-devel gcc boost
+sudo pacman -Syu --needed cmake base-devel gcc boost utf8proc
 ```
 
 2) LLVM/Clang/Lld (Arch suele proveer la versión reciente):
@@ -119,6 +119,16 @@ cmake -DLLVM_DIR=/usr/lib/llvm-20/lib/cmake/llvm ..
 find_package(Boost REQUIRED COMPONENTS program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 # target_link_libraries(tu_target PRIVATE Boost::program_options)
+```
+
+- utf8proc:
+
+```cmake
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(UTF8PROC REQUIRED utf8proc)
+include_directories(${UTF8PROC_INCLUDE_DIRS})
+link_directories(${UTF8PROC_LIBRARY_DIRS})
+# target_link_libraries(tu_target PRIVATE ${UTF8PROC_LIBRARIES})
 ```
 
 - GoogleTest (sistema):

--- a/src/preprocessor/Sanitize.cpp
+++ b/src/preprocessor/Sanitize.cpp
@@ -1,4 +1,5 @@
 #include "umbra/preprocessor/Sanitize.h"
+#include<utf8proc.h>
 #include<string>
 
 namespace umbra {
@@ -41,6 +42,16 @@ namespace umbra {
         return inputBytes;
     }
 
+    std::string normalizeEncondign(std::string& inputBytes){
+	utf8proc_uint8_t *normalized = utf8proc_NFC(reinterpret_cast<const utf8proc_uint8_t*>(inputBytes.c_str()));
+	if(!normalized){
+		return inputBytes;
+	}
+	std::string result(reinterpret_cast<char *>(normalized));
+	free(normalized);
+	return result;
+    }
+
     std::string Sanitizer::removeComments(std::string& inputBytes) {
         bool comentario = false;
         int indiceInicioComentario = -1;
@@ -65,5 +76,4 @@ namespace umbra {
         }
         return inputBytes;
     }
-
 }


### PR DESCRIPTION
Implement the normalizeEncondign() method.
Add installation instructions to setup.md.
Add utf8proc block integration directly in CMakeLists.txt.